### PR TITLE
docs: mark project as archived/not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 University project — runs locally only.
 
+## ⚠️ Status: archived, not working
+
+This project is **no longer functional** and is preserved for historical / educational purposes only:
+
+- **LATAM blocks scraping.** The site now serves anti-bot challenges that the Selenium driver in `scraper.py` does not handle. The scraper will time out or get redirected.
+- **Hardcoded dates.** `run.py` queries flights for `2024-02-03`, which is rejected by the input validation (`departure_date <= today`). Edit the dates in the file to test, but you'll still hit the LATAM block.
+- **Old pinned dependencies.** Flask 1.1, SQLAlchemy 1.3 — these only build on **Python 3.11 or earlier**. `cffi==1.16.0` fails to compile on Python 3.13+.
+
+The Flask web app + SQLite layer still runs and is a reasonable reference for a small Flask + Flask-RESTful + SQLAlchemy CRUD project.
+
 ## What it does
 
 - **Scraper** (`skytech/scraper.py`) — Selenium-based scraper that queries LATAM's website for round-trip flights between Peruvian cities (Arequipa, Lima, Cusco, etc.). Outputs JSON into `data/`.
@@ -12,7 +22,7 @@ University project — runs locally only.
 
 ## Stack
 
-Python 3.8+ · Flask 1.1 · Flask-SQLAlchemy · SQLite · Selenium 4 · ChromeDriver
+Python 3.11 (older pins won't build on 3.13+) · Flask 1.1 · Flask-SQLAlchemy · SQLite · Selenium 4 · ChromeDriver
 
 ## Local setup
 
@@ -22,11 +32,13 @@ Selenium requires a Chrome/Chromium browser installed and a matching `chromedriv
 git clone https://github.com/RayverAimar/skytech.git
 cd skytech
 
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
 
 pip install -r requirements.txt
 ```
+
+> Use Python 3.11 — the pinned `cffi==1.16.0` and `Flask==1.1.2` won't build on Python 3.13+.
 
 ## Run
 


### PR DESCRIPTION
Smoke test on Python 3.11 confirmed:

- Flask app boots fine.
- Scraper (`run.py`) fails immediately because the hardcoded `departure_date = date(2024, 2, 3)` is now in the past.
- Even with updated dates, LATAM's site now blocks the Selenium scraper.
- `cffi==1.16` and `Flask==1.1` won't build on Python 3.13+.

Adds a prominent status notice, fixes Python version requirement (3.11), and clarifies the project is preserved for educational reference only.

Recommend also archiving the repo on GitHub (Settings → Archive).